### PR TITLE
Fix RPM spec

### DIFF
--- a/scripts/sscep.spec
+++ b/scripts/sscep.spec
@@ -13,6 +13,11 @@ Source:       %{name}-%{version}.tar.gz
 URL:          https://github.com/certnanny/sscep
 Requires:     openssl >= 1:1.1.0
 
+BuildRequires: autoconf
+BuildRequires: automake
+BuildRequires: libtool
+BuildRequires: openssl-devel
+
 %description
 Simple SCEP (Simple Certificate Enrollment Protocol) client.
 
@@ -20,12 +25,16 @@ Simple SCEP (Simple Certificate Enrollment Protocol) client.
 %setup -n %{name}-%{version}
 
 %build
+./bootstrap.sh
+
 %configure
 make
 
 %install
 rm -rf $RPM_BUILD_ROOT
+
 %make_install
+install -p mkrequest $RPM_BUILD_ROOT/usr/bin
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -33,5 +42,6 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 /usr/bin/sscep
+/usr/bin/mkrequest
 %doc /usr/share/doc/sscep/COPYING
 %doc /usr/share/doc/sscep/README.md


### PR DESCRIPTION
The `sscep.spec` has been modified to add the build dependencies, to call the `bootstrap.sh`, and to include the `mkrequest` script.