### PR TITLE
Add sscep-dist image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+sscep-dist.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish SSCEP
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building SSCEP
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build sscep-builder image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        tags: sscep-builder
+        target: sscep-builder
+
+    - name: Build sscep-dist image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        tags: sscep-dist
+        target: sscep-dist
+        outputs: type=docker,dest=sscep-dist.tar
+
+    - name: Store sscep-dist image
+      uses: actions/cache@v3
+      with:
+        key: sscep-dist-${{ github.sha }}
+        path: sscep-dist.tar
+
+  publish:
+    name: Publishing SSCEP
+    if: github.event_name == 'push' && github.ref_name == 'v0.10.0-pki'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Retrieve sscep-dist image
+      uses: actions/cache@v3
+      with:
+        key: sscep-dist-${{ github.sha }}
+        path: sscep-dist.tar
+
+    - name: Publish sscep-dist image
+      run: |
+        docker load --input sscep-dist.tar
+        docker tag sscep-dist ghcr.io/${{ github.repository_owner }}/sscep-dist:latest
+        docker push ghcr.io/${{ github.repository_owner }}/sscep-dist:latest

--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sscep</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+################################################################################
+FROM registry.fedoraproject.org/fedora:latest AS sscep-builder
+
+# Install build tools
+RUN dnf install -y dnf-plugins-core rpm-build
+
+# Import SSCEP source
+COPY . /root/sscep/
+WORKDIR /root/sscep
+
+# Create source tarball
+RUN mkdir -p /root/rpmbuild/SOURCES
+RUN tar czvf /root/rpmbuild/SOURCES/sscep-0.10.0-pki.tar.gz \
+    --transform "s,^./,sscep-0.10.0-pki/," \
+    --exclude .git \
+    -C /root/sscep \
+    .
+
+# Install build dependencies
+RUN dnf builddep -y --spec scripts/sscep.spec
+
+# Build SSCEP packages
+RUN rpmbuild -ba scripts/sscep.spec
+
+# Consolidate SSCEP packages
+RUN mkdir -p /root/RPMS
+RUN find /root/rpmbuild/RPMS -mindepth 2 -type f -exec mv {} /root/RPMS \;
+
+################################################################################
+FROM alpine:latest AS sscep-dist
+
+# Import SSCEP packages
+COPY --from=sscep-builder /root/RPMS /root/RPMS/


### PR DESCRIPTION
A new GH Workflow has been added to build and publish SSCEP to GH Packages such that it can be used for CI without a COPR repo. The SSCEP RPMs will be stored in an Alpine-based image to keep the distribution small. The publishing will be done from `v0.10.0-pki` branch since that branch has been designated to store PKI-specific changes.

See also:
https://github.com/dogtagpki/sscep/wiki